### PR TITLE
Not parsing secret as json

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -95,12 +95,8 @@ jobs:
       - name: Store secret value to .env
         env:
           ENV_SECRET: ${{env.ENV_SECRET}}
-          ENV_SECRET_ID: .env.api.${{env.ENVIRONMENT}}
         shell: bash
-        run: |
-          echo "AWS Secret $ENV_SECRET_ID"
-          echo "$ENV_SECRET" | sed 's/./& /g'
-          echo "$ENV_SECRET" | jq -r '.SecretString' >> docker/app/packaged/.env
+        run: echo "$ENV_SECRET" >> docker/app/packaged/.env
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4534/spin-up-h-f-staging-instance

- The aws secret is not json, so just dump it straight to the .env file

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
